### PR TITLE
Update start_services.sh

### DIFF
--- a/start_services.sh
+++ b/start_services.sh
@@ -42,6 +42,9 @@ if [ ! -e /.initialized ]; then
     touch /.initialized
 fi
 
+# Remove stale lock file that could prevent service from starting up
+rm /var/lock/netatalk
+
 # Initiate the timemachine daemons
 chown -R $AFP_LOGIN:$AFP_LOGIN /timemachine
 /etc/init.d/netatalk start


### PR DESCRIPTION
I've discovered that on reboot/shutdown the lock file would not be removed sometimes. As a result the service would not start (tested by trying to manually starting it and reviewing the error message). This should solve this problem for rebooting/starting the container.